### PR TITLE
Ensure return value is explicitly returned

### DIFF
--- a/src/model.c
+++ b/src/model.c
@@ -25,6 +25,8 @@ static struct model *model_init(void)
         exit(1);
     }
     model->vertex_count = 0;
+
+    return model;
 }
 
 static void model_add_vertex(struct model *model, vec3 vec)
@@ -53,8 +55,8 @@ static int relativize_idx(int i, int n)
 
     if (i > 0)
         return i - 1;
-    if (i < 0)
-        return n + i;
+
+    return n + i;
 }
 
 static bool model_validate_idxs(struct model *model)


### PR DESCRIPTION
This fixes the following compiler warnings:

src/model.c:28:1: warning: non-void function does not return a value in all control paths [-Wreturn-type] (gcc makes this work, but with clang/llvm, 0x2 is returned)

src/model.c:58:1: warning: non-void function does not return a value in all control paths [-Wreturn-type] (no-op)

Thanks to oliv3 and gradator for support to debug this.

Fixes #3.